### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 before_install:
-  - pip3 install jieba3k coveralls langdetect
+  - pip3 install jieba3k coveralls langdetect nltk
 
 language: python
 python:


### PR DESCRIPTION
Straightforwards fix to the following ModuleNotFoundError. Preferable to change setup.py if possible.
zeeguu_virtual_environment is the folder created on creation of the zeeguu virtual environment
```
Using /-------/zeeguu_virtual_environment/lib/python3.6/site-packages
Finished processing dependencies for zeeguu==0.1
Traceback (most recent call last):
  File "setup.py", line 55, in <module>
    "langdetect"
  File "/--------/zeeguu_virtual_environmen/lib/python3.6/site-packages/setuptools/__init__.py", line 129, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python3.6/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib/python3.6/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "setup.py", line 11, in run
    ntlk_install_packages()
  File "setup.py", line 21, in ntlk_install_packages
    import nltk
ModuleNotFoundError: No module named 'nltk'
```
