### PR TITLE
Remove hardcoded logs folder

### DIFF
--- a/zeeguu/__init__.py
+++ b/zeeguu/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 import datetime
 
-LOGS_FOLDER = '~/.logs'
+LOGS_FOLDER = os.getenv('ZEEGUU_CORE_LOG_DIR', '~/.logs')
 
 log_dir = os.path.expanduser(LOGS_FOLDER)
 


### PR DESCRIPTION
The log dir is currently hardcoded to '~/.logs'.

This commit updates this by trying to fetch the log dir from
the environment variable ZEEGUU_CORE_LOG_DIR. If it's not set,
it will fall back to '~/.logs' for backwards compatibility.