### PR TITLE
Fixing windows pytest problems

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pytest
 flask
 Flask-SQLAlchemy
 mysqlclient
-regex==2017.5.26
+regex
 feedparser
 requests
 newspaper3k==0.2.7

--- a/zeeguu_core_test/test_data/mocking_the_web.py
+++ b/zeeguu_core_test/test_data/mocking_the_web.py
@@ -62,7 +62,7 @@ test_urls = {
 def mock_requests_get(m):
 
     def mock_requests_get_for_url(m, url):
-        f = open(os.path.join(TESTDATA_FOLDER, test_urls[url]))
+        f = open(os.path.join(TESTDATA_FOLDER, test_urls[url]),encoding="UTF-8")
         content = (f.read())
 
         m.get(url, text=content)


### PR DESCRIPTION
Fixed requirement with regex using specific version and encoding problems when loading a file.

tested with encoding="UTF-8" on ubuntu and it seemed to still work. 
Have not tested it on a mac system